### PR TITLE
Removal of jcenter as it is deprecated

### DIFF
--- a/Android/Nothing/build.gradle.kts
+++ b/Android/Nothing/build.gradle.kts
@@ -1,5 +1,5 @@
 buildscript {
-    val kotlin_version = "1.5.20"
+    val kotlin_version = "1.6.10"
 
     repositories {
         google()

--- a/Android/Nothing/build.gradle.kts
+++ b/Android/Nothing/build.gradle.kts
@@ -4,7 +4,6 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        jcenter()
         gradlePluginPortal()
 
     }
@@ -19,6 +18,5 @@ allprojects {
     repositories {
         google()
         maven(url = "https://jitpack.io")
-        jcenter()
     }
 }


### PR DESCRIPTION
- Removing jcenter from the gradle repositories
